### PR TITLE
Fix for strict mode compliance

### DIFF
--- a/plainTextParser.js
+++ b/plainTextParser.js
@@ -1,3 +1,4 @@
+"use strict"
 let plainTextParser =  (req, res, next) => {
     if (req.is('text/*')) {
         req.text = '';


### PR DESCRIPTION
NodeJS requirse `"use strict"` declaration when using `let` currently.
